### PR TITLE
Add ROI and loan payment tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "predeploy": "npm run build",
     "deploy": "gh-pages -d dist",
     "pages:build": "npm run build",
-    "pages:deploy": "npm run pages:build && gh-pages -d dist"
+    "pages:deploy": "npm run pages:build && gh-pages -d dist",
+    "test": "node --test \"src/**/*.test.ts\""
   },
   "dependencies": {
     "react": "^18.2.0",

--- a/src/utils/__tests__/purchaseCalculations.test.ts
+++ b/src/utils/__tests__/purchaseCalculations.test.ts
@@ -1,0 +1,38 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import ts from 'typescript'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+const source = readFileSync(join(__dirname, '../purchaseCalculations.ts'), 'utf8')
+const { outputText } = ts.transpileModule(source, { compilerOptions: { module: ts.ModuleKind.CommonJS } })
+const module: { exports: any } = { exports: {} }
+const wrapper = new Function('module', 'exports', outputText)
+wrapper(module, module.exports)
+const { calculateROI, calculateMonthlyLoanPayment } = module.exports as {
+  calculateROI: (initialInvestment: number, finalAssets: number, totalCost: number) => number
+  calculateMonthlyLoanPayment: (principal: number, annualRate: number, months: number) => number
+}
+
+test('calculateMonthlyLoanPayment returns principal divided by months when interest is 0%', () => {
+  const payment = calculateMonthlyLoanPayment(1200, 0, 12)
+  assert.equal(payment, 100)
+})
+
+test('calculateMonthlyLoanPayment calculates correct payment with positive interest', () => {
+  const payment = calculateMonthlyLoanPayment(1000, 0.12, 12)
+  assert.ok(Math.abs(payment - 88.84878867834166) < 1e-6)
+})
+
+test('calculateROI returns 0 when final assets equal total cost', () => {
+  const roi = calculateROI(1000, 1000, 1000)
+  assert.equal(roi, 0)
+})
+
+test('calculateROI returns positive percentage when final assets exceed cost', () => {
+  const roi = calculateROI(1000, 1100, 1000)
+  assert.equal(roi, 10)
+})


### PR DESCRIPTION
## Summary
- add tests for calculateROI and calculateMonthlyLoanPayment
- run tests via Node test runner

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abf4a433b08322b978a48778f39449